### PR TITLE
住所登録機能の実装

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,7 +1,29 @@
 class AddressesController < ApplicationController
   def create
+    @address = Address.new(address_params)
+    @address.customer_id = current_customer.id
+    if @address.save
+      redirect_to new_customer_order_path(current_customer)
+    else
+      @address_error = "住所登録のエラーです"
+      @cart_items = current_customer.cart_items.all
+      @order_error = false
+      @sum=0
+      current_customer.cart_items.each do |cart|
+          @sum += cart.item.price
+      end
+      render ("orders/new")
+    end 
   end
 
   def destroy
+    @address = Address.find(params[:id])
+    @address.delete
+    redirect_to new_customer_order_path(current_customer)
   end
+
+  private
+    def address_params
+      params.require(:address).permit(:post_code,:prefecture,:city,:street)
+    end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,6 @@
 class OrdersController < ApplicationController
     def new
+        @address = Address.new
         @cart_items = current_customer.cart_items.all
         @order_error = false
         @sum=0
@@ -12,6 +13,7 @@ class OrdersController < ApplicationController
         # もしも商品の在庫がなければredirect
         current_customer.cart_items.each do |cart|
             if cart.count > cart.item.stock
+                @address = Address.new
                 @cart_items = current_customer.cart_items.all
                 @order_error = "購入分の在庫がありません"
                 render ("orders/new")

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,8 @@
 class Address < ApplicationRecord
     belongs_to :customer
+
+    validates :post_code, presence: true
+    validates :prefecture, presence: true
+    validates :city, presence: true
+    validates :street, presence: true
 end

--- a/app/views/admin/item_kinds/index.html.slim
+++ b/app/views/admin/item_kinds/index.html.slim
@@ -1,5 +1,6 @@
 .container.item-kinds
   h1 アーティスト、レーベル、ジャンル管理ページ
+  = link_to  "戻る", admin_home_index_path, class: "btn btn-info"
   .row
     .col-lg-12
       = render  "layouts/errors", model: @genre, model_error: @genre_error

--- a/app/views/admin/items/index.html.slim
+++ b/app/views/admin/items/index.html.slim
@@ -1,4 +1,5 @@
 h1 #index.html
+= link_to  "戻る", admin_home_index_path, class: "btn btn-info"
 = link_to  "新規商品登録ページ", new_admin_item_path, class: "btn btn-success"
 br/
 - @items.each do |item|

--- a/app/views/admin/orders/index.html.slim
+++ b/app/views/admin/orders/index.html.slim
@@ -23,6 +23,8 @@ br/
           = " 受注日: #{order.created_at}|"
           = "  支払い方法: #{order.payment}"
           = "  合計金額: #{order.sum}円"
+          br/
+          = "  配送先住所: #{order.address}"
           = link_to  "配送する", admin_order_path(order), method: :put, data: { confirm: "ステータスを配達中にしても大丈夫ですか？"}
           br/
       #admin-sent
@@ -33,6 +35,8 @@ br/
           = " 受注日: #{order.created_at}|"
           = "  支払い方法: #{order.payment}"
           = "  合計金額: #{order.sum}円"
+          br/
+          = "  配送先住所: #{order.address}"
           = link_to  "配達完了", admin_order_path(order), method: :put, data: { confirm: "ステータスを配達済みにしても大丈夫ですか？"}
           br/
       #admin-delivered
@@ -43,6 +47,8 @@ br/
           = " 受注日: #{order.created_at}|"
           = "  支払い方法: #{order.payment}"
           = "  合計金額: #{order.sum}円"
+          br/
+          = "  配送先住所: #{order.address}"
           br/
 
 

--- a/app/views/orders/new.html.slim
+++ b/app/views/orders/new.html.slim
@@ -6,15 +6,34 @@ br/
 - @cart_items.each do |cart|
   = attachment_image_tag cart.item, :image, :fill, 50,50
 
+| 新しく住所を追加する
+= render "layouts/errors", model: @address, model_error: @address_error
+= form_with model: @address, url: customer_addresses_path(current_customer), method: :post, local: true do |address|
+  | 郵便番号
+  = address.text_field :post_code
+  | 都道府県
+  = address.text_field :prefecture
+  | 市区町村
+  = address.text_field :city
+  | 番地、その他
+  = address.text_field :street
+  br/
+  = address.submit "住所登録する"
+  br/
+
 = form_with url: customer_orders_path(current_customer), method: :post do |form|
   = form.label :address, "配送先住所選択"
   br/
   = current_customer.prefecture+current_customer.city+current_customer.street
   = form.radio_button :address, current_customer.prefecture+current_customer.city+current_customer.street, checked: true
   - current_customer.addresses.each do |address|
-    = current_customer.prefecture+current_customer.city+current_customer.street
-    = form.radio_button :address, address.prefecture+address.city+address+street
+    br/
+    = address.prefecture+address.city+address.street
+    = form.radio_button :address, address.prefecture+address.city+address.street
+    = link_to  "削除する", customer_address_path(current_customer, address), data: { confirm: "削除しても大丈夫ですか？"}, method: :delete
   br/
+
+
   = form.label :payment, "支払い方法選択"
     br/
     | クレジットカード


### PR DESCRIPTION
close #92 
購入画面で住所を登録できるようにしました
削除機能実装しました
メイン住所がaddressesテーブルの中に保存されていない(ユーザー登録時にユーザーの情報として持ってしまっている)のでメイン住所だけ削除できません
このまま放置でもいいですがなんかいいアイデアあったらぜひissue立ててください