### PR TITLE
商品の一覧と検索ページの整形+α

### DIFF
--- a/app/assets/stylesheets/searches.scss
+++ b/app/assets/stylesheets/searches.scss
@@ -1,3 +1,13 @@
 // Place all the styles related to the searches controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.search-item-box{
+    margin:10px 1% 10px 1%;
+    width: 23%;
+    display: inline-block;
+    text-align: center;
+    border: solid 1px gray;
+    a:link, a:visited {
+        color: gray;
+    }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,13 +1,16 @@
 class ItemsController < ApplicationController
   before_action :signed_customer_redirect
+  
   def index
-  	@items = Item.where(ready: true)
+  	@items = Item.where(ready: true).reverse
   end
   
   def show
     @item = Item.find(params[:id])
     @cart_item = @item.cart_item.new
-    @exist = @item.favorites.where(customer_id: current_customer.id).exists?
+    if customer_signed_in?
+      @exist = @item.favorites.where(customer_id: current_customer.id).exists?
+    end
   end
 
   private

--- a/app/views/items/index.html.slim
+++ b/app/views/items/index.html.slim
@@ -1,10 +1,12 @@
-h1 Items#index
-div.announce
-   - @items.each do |item|
-      = item.name
-      = attachment_image_tag item, :image, :fill, 50, 50
-      = link_to  "詳細ページへ", item_path(item), class: "btn btn-info", data: {"turbolinks" => false}
-      / =item.singer.name
-      / =item.favorites.count
-      =item.price
+h1 
+  strong 新着商品
+.container
+  .row
+    - @items.each do |item|
+        .search-item-box
+          = link_to  item_path(item) do
+            = attachment_image_tag item, :image, :fill, 200, 200
+          p
+            b = link_to  item.name, item_path(item)
+          = item.singer.name
 / ページネイション挿入

--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -12,13 +12,14 @@ div.item-container.flex
     div.image-box
       / refileで挿入するので多分↓はimage_tagとかそんな感じだった気がする
       / =@item.image
-    div.favorites-box
-      - if @exist
-        = link_to item_favorite_path(@item), data: {"turbolinks" => false}, method: :delete do
-          i class="fa fa-heart" aria-hidden="true" style="color: red"
-      - else
-        = link_to  item_favorite_path(@item), data: {"turbolinks" => false}, method: :post do
-          i class="fa fa-heart" aria-hidden="true" style="color: gray;"
+    - if customer_signed_in?  
+      div.favorites-box
+        - if @exist
+          = link_to item_favorite_path(@item), data: {"turbolinks" => false}, method: :delete do
+            i class="fa fa-heart" aria-hidden="true" style="color: red"
+        - else
+          = link_to  item_favorite_path(@item), data: {"turbolinks" => false}, method: :post do
+            i class="fa fa-heart" aria-hidden="true" style="color: gray;"
       / いいねのハート
       =@item.favorites.count
   / 画面右側
@@ -36,9 +37,10 @@ div.item-container.flex
 
 
 / カートに入れる
-= form_for(@cart_item, url: customer_cart_items_path(current_customer), method: :post) do |form|
-  = form.label :count, "個数"
-  = form.number_field :count, in: 1.0..@item.stock, step: 1.0
-  = form.hidden_field :item_id, value: @item.id
-  br/
-  = form.submit
+= if customer_signed_in?
+  = form_for(@cart_item, url: customer_cart_items_path(current_customer), method: :post) do |form|
+    = form.label :count, "個数"
+    = form.number_field :count, in: 1.0..@item.stock, step: 1.0
+    = form.hidden_field :item_id, value: @item.id
+    br/
+    = form.submit

--- a/app/views/searches/index.html.slim
+++ b/app/views/searches/index.html.slim
@@ -1,26 +1,47 @@
+H1 検索結果
+H2 = "#{params[:search]}: 商品"
 .container
   .row
-    .col-lg-3
-      h2 商品
-      - @items.each do |item|
-        br/
-        = link_to  "#{item.name}", item_path(item)
-        br/
-    .col-lg-3
-      h2 歌手
-      - @singers.each do |singer|
-        br
-        = singer.name
-        br/
-    .col-lg-3
-      h2 レーベル
-      - @labels.each do |label|
-        br/
-        = label.name
-        br/
-    .col-lg-3
-      h2 ジャンル
-      - @genres.each do |genre|
-        br/
-        = genre.name
-        br/
+    - @items.each do |item|
+        .search-item-box
+          = link_to  item_path(item) do
+            = attachment_image_tag item, :image, :fill, 200, 200
+          p
+            b = link_to  item.name, item_path(item)
+          = item.singer.name
+
+H2 = "#{params[:search]}: アーティスト"
+.container
+  .row
+    - @singers.each do |singer|
+      - singer.items.each do |item|
+        .search-item-box
+          = link_to  item_path(item) do
+            = attachment_image_tag item, :image, :fill, 200, 200
+          p
+            b = link_to  item.name, item_path(item)
+          = singer.name
+
+H2 = "#{params[:search]}: レーベル"
+.container
+  .row
+    - @labels.each do |label|
+      - label.items.each do |item|
+        .search-item-box
+          = link_to  item_path(item) do
+            = attachment_image_tag item, :image, :fill, 200, 200
+          p
+            b = link_to  item.name, item_path(item)
+          = item.singer.name
+
+H2 = "#{params[:search]}: ジャンル"
+.container
+  .row
+    - @genres.each do |genre|
+      - genre.items.each do |item|
+        .search-item-box
+          = link_to  item_path(item) do
+            = attachment_image_tag item, :image, :fill, 200, 200
+          p
+            b = link_to  item.name, item_path(item)
+          = item.singer.name


### PR DESCRIPTION
# 🤗 実装した機能
- 商品の一覧整形
- 検索ページの整形
- 商品詳細のバグ修正

# 🤔 実装方法
- 商品一覧、検索ページはほぼレイアウト同じにした
  - 横に４つ商品が並ぶ
- ログインしないまま商品詳細に行くとcustomeridを要求される記述があるのでそこで死ぬ
  - ハートの非表示、カートに入れるボタンの非表示で対処
  - `customer_signed_in?`で対処した


# 😇 その他
- 触っててバグがあったらすぐに報告してください